### PR TITLE
fix: resolve all compiler warnings

### DIFF
--- a/src/IndexSet.mbt
+++ b/src/IndexSet.mbt
@@ -18,9 +18,10 @@ let default_init_capacity = 8
 
 ///|
 /// Create new indexed hash set.
+
 ///|
 /// Create new indexed hash set.
-pub fn new[K](capacity~ : Int = default_init_capacity) -> T[K] {
+pub fn[K] new(capacity~ : Int = default_init_capacity) -> T[K] {
   {
     core: {
       hash_to_idx: @hashmap.new(),
@@ -39,14 +40,14 @@ pub fn new[K](capacity~ : Int = default_init_capacity) -> T[K] {
 
 ///|
 /// Create new indexed hash set from array.
-pub fn from_array[K : Hash + Eq](arr : Array[K]) -> T[K] {
+pub fn[K : Hash + Eq] from_array(arr : Array[K]) -> T[K] {
   let set = new()
   arr.each(fn(e) { set.add(e) })
   set
 }
 
 ///|
-pub fn of[K : Hash + Eq](arr : FixedArray[K]) -> T[K] {
+pub fn[K : Hash + Eq] of(arr : FixedArray[K]) -> T[K] {
   let set = new()
   arr.each(fn(e) { set.add(e) })
   set
@@ -57,13 +58,13 @@ pub fn of[K : Hash + Eq](arr : FixedArray[K]) -> T[K] {
 /// @alert unsafe "Panic if the hash set is full."
 #deprecated("Use `add` instead.")
 #coverage.skip
-pub fn insert[K : Hash + Eq](self : T[K], key : K) -> Unit {
+pub fn[K : Hash + Eq] insert(self : T[K], key : K) -> Unit {
   self.add(key)
 }
 
 ///|
 /// Add a key to the hash set.
-pub fn add[K : Hash + Eq](self : T[K], key : K) -> Unit {
+pub fn[K : Hash + Eq] add(self : T[K], key : K) -> Unit {
   // 检查是否需要扩容
   if self.capacity == 0 || self.size >= self.growAt {
     self.grow()
@@ -121,7 +122,7 @@ pub fn add[K : Hash + Eq](self : T[K], key : K) -> Unit {
 
 ///|
 /// Get element at specific index
-pub fn get_at[K](self : T[K], index : Int) -> K? {
+pub fn[K] get_at(self : T[K], index : Int) -> K? {
   if index < 0 || index >= self.size {
     return None
   }
@@ -135,7 +136,7 @@ pub fn get_at[K](self : T[K], index : Int) -> K? {
 
 ///|
 /// Get the index of a key
-pub fn index_of[K : Hash + Eq](self : T[K], key : K) -> Int? {
+pub fn[K : Hash + Eq] index_of(self : T[K], key : K) -> Int? {
   // 先检查键是否存在
   // 从桶索引到位置的映射获取位置索引
   match self.key_to_idx.get(key) {
@@ -146,7 +147,7 @@ pub fn index_of[K : Hash + Eq](self : T[K], key : K) -> Int? {
 
 ///|
 /// Check if the hash set contains a key.
-pub fn contains[K : Hash + Eq](self : T[K], key : K) -> Bool {
+pub fn[K : Hash + Eq] contains(self : T[K], key : K) -> Bool {
   if self.size == 0 {
     return false
   }
@@ -158,7 +159,7 @@ pub fn contains[K : Hash + Eq](self : T[K], key : K) -> Bool {
 ///|
 
 ///| Remove a key from hash set with O(1) complexity.
-pub fn remove[K : Hash + Eq](self : T[K], key : K) -> Unit {
+pub fn[K : Hash + Eq] remove(self : T[K], key : K) -> Unit {
   if self.size == 0 {
     return
   }
@@ -222,31 +223,31 @@ pub fn remove[K : Hash + Eq](self : T[K], key : K) -> Unit {
 
 ///|
 /// Get the number of keys in the set.
-pub fn size[K](self : T[K]) -> Int {
+pub fn[K] size(self : T[K]) -> Int {
   self.size
 }
 
 ///|
 /// Get the capacity of the set.
-pub fn capacity[K](self : T[K]) -> Int {
+pub fn[K] capacity(self : T[K]) -> Int {
   self.capacity
 }
 
 ///|
 /// Check if the hash set is empty.
-pub fn is_empty[K](self : T[K]) -> Bool {
+pub fn[K] is_empty(self : T[K]) -> Bool {
   self.size == 0
 }
 
 ///|
 /// Iterate over all keys of the set.
-pub fn each[K](self : T[K], f : (K) -> Unit) -> Unit {
+pub fn[K] each(self : T[K], f : (K) -> Unit) -> Unit {
   self.eachi(fn(_i, k) { f(k) })
 }
 
 ///|
 /// Iterate over all keys of the set, with index.
-pub fn eachi[K](self : T[K], f : (Int, K) -> Unit) -> Unit {
+pub fn[K] eachi(self : T[K], f : (Int, K) -> Unit) -> Unit {
   let mut current = self.core.head
   let mut index = 0
   while current != -1 {
@@ -258,7 +259,7 @@ pub fn eachi[K](self : T[K], f : (Int, K) -> Unit) -> Unit {
 
 ///|
 /// Clears the set, removing all keys. Keeps the allocated space.
-pub fn clear[K](self : T[K]) -> Unit {
+pub fn[K] clear(self : T[K]) -> Unit {
   self.core.hash_to_idx = @hashmap.new() // 重置为新的哈希表
   self.core.entries = []
   self.core.head = -1
@@ -272,7 +273,7 @@ pub fn clear[K](self : T[K]) -> Unit {
 ///|
 /// Union of two hash sets.
 /// @alert unsafe "Panic if the hash set is full."
-pub fn union[K : Hash + Eq](self : T[K], other : T[K]) -> T[K] {
+pub fn[K : Hash + Eq] union(self : T[K], other : T[K]) -> T[K] {
   let result = new()
   self.each(fn(k) { result.add(k) })
   other.each(fn(k) { result.add(k) })
@@ -281,7 +282,7 @@ pub fn union[K : Hash + Eq](self : T[K], other : T[K]) -> T[K] {
 
 ///|
 /// Intersection of two hash sets.
-pub fn intersection[K : Hash + Eq](self : T[K], other : T[K]) -> T[K] {
+pub fn[K : Hash + Eq] intersection(self : T[K], other : T[K]) -> T[K] {
   let result = new()
   self.each(fn(k) { if other.contains(k) { result.add(k) } })
   result
@@ -289,7 +290,7 @@ pub fn intersection[K : Hash + Eq](self : T[K], other : T[K]) -> T[K] {
 
 ///|
 /// Difference of two hash sets.
-pub fn difference[K : Hash + Eq](self : T[K], other : T[K]) -> T[K] {
+pub fn[K : Hash + Eq] difference(self : T[K], other : T[K]) -> T[K] {
   let result = new()
   self.each(fn(k) { if not(other.contains(k)) { result.add(k) } })
   result
@@ -297,7 +298,7 @@ pub fn difference[K : Hash + Eq](self : T[K], other : T[K]) -> T[K] {
 
 ///|
 /// Symmetric difference of two hash sets.
-pub fn symmetric_difference[K : Hash + Eq](self : T[K], other : T[K]) -> T[K] {
+pub fn[K : Hash + Eq] symmetric_difference(self : T[K], other : T[K]) -> T[K] {
   let result = new()
   self.each(fn(k) { if not(other.contains(k)) { result.add(k) } })
   other.each(fn(k) { if not(self.contains(k)) { result.add(k) } })
@@ -305,7 +306,7 @@ pub fn symmetric_difference[K : Hash + Eq](self : T[K], other : T[K]) -> T[K] {
 }
 
 ///|
-pub fn iter[K](self : T[K]) -> Iter[K] {
+pub fn[K] iter(self : T[K]) -> Iter[K] {
   Iter::new(fn(yield_) {
     let mut current = self.core.head
     while current != -1 {
@@ -320,7 +321,7 @@ pub fn iter[K](self : T[K]) -> Iter[K] {
 }
 
 ///|
-pub fn from_iter[K : Hash + Eq](iter : Iter[K]) -> T[K] {
+pub fn[K : Hash + Eq] from_iter(iter : Iter[K]) -> T[K] {
   let s = new()
   iter.each(fn(e) { s.add(e) })
   s
@@ -328,7 +329,7 @@ pub fn from_iter[K : Hash + Eq](iter : Iter[K]) -> T[K] {
 
 ///|
 /// Convert set to array, preserving insertion order.
-pub fn to_array[K](self : T[K]) -> Array[K] {
+pub fn[K] to_array(self : T[K]) -> Array[K] {
   if self.size == 0 || self.core.head == -1 {
     return []
   }
@@ -345,19 +346,21 @@ pub fn to_array[K](self : T[K]) -> Array[K] {
 
 ///|
 /// Insert an entry into the hash table
-fn insert_into_table[K : Hash](
+fn[K : Hash] insert_into_table(
   self : T[K],
   hash : Int,
-  bucket_idx : Int
+  bucket_idx : Int,
 ) -> Unit {
   // 直接在哈希表中设置键值对，无需线性探测
   self.core.hash_to_idx.set(hash, bucket_idx)
 }
 
 ///|
+
 ///|
+
 ///|
-fn grow[K : Hash + Eq](self : T[K]) -> Unit {
+fn[K : Hash + Eq] grow(self : T[K]) -> Unit {
   // 保存旧数据
   let old_entries = self.core.entries
   let old_head = self.core.head
@@ -396,7 +399,7 @@ pub impl[K : Show] Show for T[K] with output(self, logger) {
 ///|
 /// 移除并返回最后一个插入的元素（尾部元素）
 /// 如果集合为空，返回 None
-pub fn pop[K : Hash + Eq](self : T[K]) -> K? {
+pub fn[K : Hash + Eq] pop(self : T[K]) -> K? {
   if self.size == 0 {
     return None
   }
@@ -438,7 +441,7 @@ pub fn pop[K : Hash + Eq](self : T[K]) -> K? {
 ///|
 /// 移除并返回第一个插入的元素（头部元素）
 /// 时间复杂度：O(1)
-pub fn shift[K : Hash + Eq](self : T[K]) -> K? {
+pub fn[K : Hash + Eq] shift(self : T[K]) -> K? {
   if self.size == 0 {
     return None
   }
@@ -489,7 +492,7 @@ pub fn shift[K : Hash + Eq](self : T[K]) -> K? {
 
 ///| 返回集合中第一个插入的元素，但不移除它
 /// 如果集合为空，返回 None
-pub fn peek_first[K](self : T[K]) -> K? {
+pub fn[K] peek_first(self : T[K]) -> K? {
   if self.size == 0 || self.core.head == -1 {
     return None
   }
@@ -504,7 +507,7 @@ pub fn peek_first[K](self : T[K]) -> K? {
 
 ///| 返回集合中最后一个插入的元素，但不移除它
 /// 如果集合为空，返回 None
-pub fn peek_last[K](self : T[K]) -> K? {
+pub fn[K] peek_last(self : T[K]) -> K? {
   if self.size == 0 || self.core.tail == -1 {
     return None
   }
@@ -520,14 +523,14 @@ pub fn peek_last[K](self : T[K]) -> K? {
 ///|
 pub impl[X : @quickcheck.Arbitrary + Eq + Hash] @quickcheck.Arbitrary for T[X] with arbitrary(
   size,
-  rs
+  rs,
 ) {
   @quickcheck.Arbitrary::arbitrary(size, rs) |> from_iter
 }
 
 ///| 返回一个按照指定比较函数排序的新集合
 /// 原集合不会被修改
-pub fn sorted[K : Hash + Eq](self : T[K], compare : (K, K) -> Int) -> T[K] {
+pub fn[K : Hash + Eq] sorted(self : T[K], compare : (K, K) -> Int) -> T[K] {
   // 将集合转换为数组
   let arr = self.to_array()
 
@@ -539,15 +542,15 @@ pub fn sorted[K : Hash + Eq](self : T[K], compare : (K, K) -> Int) -> T[K] {
 }
 
 ///|
-pub fn sorted_by_key[K : Hash + Eq + Compare](self : T[K]) -> T[K] {
+pub fn[K : Hash + Eq + Compare] sorted_by_key(self : T[K]) -> T[K] {
   self.sorted(fn(a, b) { a.compare(b) })
 }
 
 ///| 返回一个按照键映射函数排序的新集合
 /// 原集合不会被修改
-pub fn sorted_by[K : Hash + Eq, B : Compare](
+pub fn[K : Hash + Eq, B : Compare] sorted_by(
   self : T[K],
-  key_fn : (K) -> B
+  key_fn : (K) -> B,
 ) -> T[K] {
   // 将集合转换为数组
   let arr = self.to_array()
@@ -562,7 +565,7 @@ pub fn sorted_by[K : Hash + Eq, B : Compare](
 ///|
 /// 就地排序集合元素
 /// 时间复杂度: O(n log n)，其中n是集合大小
-pub fn sort[K : Hash + Eq](self : T[K], compare : (K, K) -> Int) -> Unit {
+pub fn[K : Hash + Eq] sort(self : T[K], compare : (K, K) -> Int) -> Unit {
   if self.size <= 1 {
     return
   }
@@ -587,39 +590,39 @@ pub fn sort[K : Hash + Eq](self : T[K], compare : (K, K) -> Int) -> Unit {
 ///|
 /// 就地按照自然顺序排序集合
 /// 要求元素类型实现了 Compare trait
-pub fn sort_by_key[K : Hash + Eq + Compare](self : T[K]) -> Unit {
+pub fn[K : Hash + Eq + Compare] sort_by_key(self : T[K]) -> Unit {
   self.sort(fn(a, b) { a.compare(b) })
 }
 
 ///|
 /// 就地按照键映射函数排序集合
-pub fn sort_by[K : Hash + Eq, B : Compare](
+pub fn[K : Hash + Eq, B : Compare] sort_by(
   self : T[K],
-  key_fn : (K) -> B
+  key_fn : (K) -> B,
 ) -> Unit {
   self.sort(fn(a, b) { key_fn(a).compare(key_fn(b)) })
 }
 
 ///|
 /// 返回一个按照指定比较函数反向排序的新集合
-pub fn sorted_desc[K : Hash + Eq](self : T[K], compare : (K, K) -> Int) -> T[K] {
+pub fn[K : Hash + Eq] sorted_desc(self : T[K], compare : (K, K) -> Int) -> T[K] {
   self.sorted(fn(a, b) { compare(b, a) })
 }
 
 ///|
 /// 返回一个按照自然顺序反向排序的新集合
-pub fn sorted_by_key_desc[K : Hash + Eq + Compare](self : T[K]) -> T[K] {
+pub fn[K : Hash + Eq + Compare] sorted_by_key_desc(self : T[K]) -> T[K] {
   self.sorted(fn(a, b) { b.compare(a) })
 }
 
 ///|
 /// 就地按照指定比较函数反向排序集合
-pub fn sort_desc[K : Hash + Eq](self : T[K], compare : (K, K) -> Int) -> Unit {
+pub fn[K : Hash + Eq] sort_desc(self : T[K], compare : (K, K) -> Int) -> Unit {
   self.sort(fn(a, b) { compare(b, a) })
 }
 
 ///|
 /// 就地按照自然顺序反向排序集合
-pub fn sort_by_key_desc[K : Hash + Eq + Compare](self : T[K]) -> Unit {
+pub fn[K : Hash + Eq + Compare] sort_by_key_desc(self : T[K]) -> Unit {
   self.sort(fn(a, b) { b.compare(a) })
 }

--- a/src/IndexSet.mbt
+++ b/src/IndexSet.mbt
@@ -346,11 +346,7 @@ pub fn[K] to_array(self : T[K]) -> Array[K] {
 
 ///|
 /// Insert an entry into the hash table
-fn[K : Hash] insert_into_table(
-  self : T[K],
-  hash : Int,
-  bucket_idx : Int,
-) -> Unit {
+fn[K] insert_into_table(self : T[K], hash : Int, bucket_idx : Int) -> Unit {
   // 直接在哈希表中设置键值对，无需线性探测
   self.core.hash_to_idx.set(hash, bucket_idx)
 }

--- a/src/IndexSet.mbti
+++ b/src/IndexSet.mbti
@@ -1,97 +1,56 @@
+// Generated using `moon info`, DON'T EDIT IT
 package "kesmeey/IndexSet"
 
-
+import(
+  "moonbitlang/core/quickcheck"
+)
 
 // Values
-fn add[K : Hash + Eq](T[K], K) -> Unit
+fn[K : Hash + Eq] from_array(Array[K]) -> T[K]
 
-fn capacity[K](T[K]) -> Int
+fn[K : Hash + Eq] from_iter(Iter[K]) -> T[K]
 
-fn clear[K](T[K]) -> Unit
+fn[K] new(capacity? : Int) -> T[K]
 
-fn contains[K : Hash + Eq](T[K], K) -> Bool
+fn[K : Hash + Eq] of(FixedArray[K]) -> T[K]
 
-fn difference[K : Hash + Eq](T[K], T[K]) -> T[K]
-
-fn each[K](T[K], (K) -> Unit) -> Unit
-
-fn eachi[K](T[K], (Int, K) -> Unit) -> Unit
-
-fn from_array[K : Hash + Eq](Array[K]) -> T[K]
-
-fn from_iter[K : Hash + Eq](Iter[K]) -> T[K]
-
-
-#deprecated
-fn insert[K : Hash + Eq](T[K], K) -> Unit
-
-fn intersection[K : Hash + Eq](T[K], T[K]) -> T[K]
-
-fn is_empty[K](T[K]) -> Bool
-
-fn iter[K](T[K]) -> Iter[K]
-
-fn new[K](capacity~ : Int = ..) -> T[K]
-
-fn of[K : Hash + Eq](FixedArray[K]) -> T[K]
-
-fn remove[K : Hash + Eq](T[K], K) -> Unit
-
-fn size[K](T[K]) -> Int
-
-fn symmetric_difference[K : Hash + Eq](T[K], T[K]) -> T[K]
-
-fn to_array[K](T[K]) -> Array[K]
-
-fn union[K : Hash + Eq](T[K], T[K]) -> T[K]
+// Errors
 
 // Types and methods
-fn get_at[K](T[K], Int) -> K?
-
-fn index_of[K : Eq](T[K], K) -> Int?
-
-fn pop[K](self : T[K]) -> K?
-
-fn shift[K](self : T[K]) -> K?
-
-fn peek_first[K](self : T[K]) -> K?
-
-fn peek_last[K](self : T[K]) -> K? 
-
 type T[K]
-impl T {
-  add[K : Hash + Eq](Self[K], K) -> Unit
-  capacity[K](Self[K]) -> Int
-  clear[K](Self[K]) -> Unit
-  contains[K : Hash + Eq](Self[K], K) -> Bool
-  difference[K : Hash + Eq](Self[K], Self[K]) -> Self[K]
-  each[K](Self[K], (K) -> Unit) -> Unit
-  eachi[K](Self[K], (Int, K) -> Unit) -> Unit
-  #deprecated
-  from_array[K : Hash + Eq](Array[K]) -> Self[K]
-  #deprecated
-  from_iter[K : Hash + Eq](Iter[K]) -> Self[K]
-  #deprecated
-  insert[K : Hash + Eq](Self[K], K) -> Unit
-  intersection[K : Hash + Eq](Self[K], Self[K]) -> Self[K]
-  is_empty[K](Self[K]) -> Bool
-  iter[K](Self[K]) -> Iter[K]
-  #deprecated
-  new[K](capacity~ : Int = ..) -> Self[K]
-  #deprecated
-  of[K : Hash + Eq](FixedArray[K]) -> Self[K]
-  remove[K : Hash + Eq](Self[K], K) -> Unit
-  size[K](Self[K]) -> Int
-  symmetric_difference[K : Hash + Eq](Self[K], Self[K]) -> Self[K]
-  to_array[K](Self[K]) -> Array[K]
-  union[K : Hash + Eq](Self[K], Self[K]) -> Self[K]
-  get_at[K](T[K], Int) -> K?
-  index_of[K : Eq](T[K], K) -> Int?
-  pop[K](self : T[K]) -> K?
-  shift[K](self : T[K]) -> K?
-  peek_last[K](self : T[K]) -> K? 
-  peek_first[K](self : T[K]) -> K? 
-}
+fn[K : Hash + Eq] T::add(Self[K], K) -> Unit
+fn[K] T::capacity(Self[K]) -> Int
+fn[K] T::clear(Self[K]) -> Unit
+fn[K : Hash + Eq] T::contains(Self[K], K) -> Bool
+fn[K : Hash + Eq] T::difference(Self[K], Self[K]) -> Self[K]
+fn[K] T::each(Self[K], (K) -> Unit) -> Unit
+fn[K] T::eachi(Self[K], (Int, K) -> Unit) -> Unit
+fn[K] T::get_at(Self[K], Int) -> K?
+fn[K : Hash + Eq] T::index_of(Self[K], K) -> Int?
+#deprecated
+fn[K : Hash + Eq] T::insert(Self[K], K) -> Unit
+fn[K : Hash + Eq] T::intersection(Self[K], Self[K]) -> Self[K]
+fn[K] T::is_empty(Self[K]) -> Bool
+fn[K] T::iter(Self[K]) -> Iter[K]
+fn[K] T::peek_first(Self[K]) -> K?
+fn[K] T::peek_last(Self[K]) -> K?
+fn[K : Hash + Eq] T::pop(Self[K]) -> K?
+fn[K : Hash + Eq] T::remove(Self[K], K) -> Unit
+fn[K : Hash + Eq] T::shift(Self[K]) -> K?
+fn[K] T::size(Self[K]) -> Int
+fn[K : Hash + Eq] T::sort(Self[K], (K, K) -> Int) -> Unit
+fn[K : Hash + Eq, B : Compare] T::sort_by(Self[K], (K) -> B) -> Unit
+fn[K : Hash + Eq + Compare] T::sort_by_key(Self[K]) -> Unit
+fn[K : Hash + Eq + Compare] T::sort_by_key_desc(Self[K]) -> Unit
+fn[K : Hash + Eq] T::sort_desc(Self[K], (K, K) -> Int) -> Unit
+fn[K : Hash + Eq] T::sorted(Self[K], (K, K) -> Int) -> Self[K]
+fn[K : Hash + Eq, B : Compare] T::sorted_by(Self[K], (K) -> B) -> Self[K]
+fn[K : Hash + Eq + Compare] T::sorted_by_key(Self[K]) -> Self[K]
+fn[K : Hash + Eq + Compare] T::sorted_by_key_desc(Self[K]) -> Self[K]
+fn[K : Hash + Eq] T::sorted_desc(Self[K], (K, K) -> Int) -> Self[K]
+fn[K : Hash + Eq] T::symmetric_difference(Self[K], Self[K]) -> Self[K]
+fn[K] T::to_array(Self[K]) -> Array[K]
+fn[K : Hash + Eq] T::union(Self[K], Self[K]) -> Self[K]
 impl[K : Show] Show for T[K]
 impl[X : @quickcheck.Arbitrary + Eq + Hash] @quickcheck.Arbitrary for T[X]
 

--- a/src/IndexSet_test.mbt
+++ b/src/IndexSet_test.mbt
@@ -292,14 +292,14 @@ test "IndexSet arbitrary" {
 ///|
 test "@IndexSet.to_array/empty" {
   let set : @IndexSet.T[Int] = @IndexSet.new()
-  inspect(@IndexSet.to_array(set), content="[]")
+  inspect(set.to_array(), content="[]")
 }
 
 ///|
 test "@IndexSet.to_array/single" {
   let set = @IndexSet.new()
   set.add(42)
-  inspect(@IndexSet.to_array(set), content="[42]")
+  inspect(set.to_array(), content="[42]")
 }
 
 ///|
@@ -309,7 +309,7 @@ test "@IndexSet.to_array/multiple" {
   set.add(2)
   set.add(3)
   set.add(4)
-  inspect(@IndexSet.to_array(set), content="[1, 2, 3, 4]")
+  inspect(set.to_array(), content="[1, 2, 3, 4]")
 }
 
 ///|
@@ -545,7 +545,7 @@ test "get_at basic functionality" {
   for i in 0..<set.size() {
     match set.get_at(i) {
       Some(v) => values.push(v)
-      None => ignore(None) // 不应发生
+      None => () // 不应发生
     }
   }
   assert_eq(values, [10, 20, 30, 40, 50])
@@ -561,7 +561,7 @@ test "get_at boundary cases" {
   assert_eq(set.get_at(100), None) // 远超越界索引
 
   // 空集合测试
-  let empty_set = @IndexSet.new()
+  let empty_set : @IndexSet.T[String] = @IndexSet.new()
   assert_eq(empty_set.get_at(0), None) // 空集合任何索引都返回None
 }
 

--- a/src/IndexSet_test.mbt
+++ b/src/IndexSet_test.mbt
@@ -20,21 +20,21 @@ test "doc" {
   let set1 = @IndexSet.of([3, 8, 1])
   set1.add(3)
   set1.add(4)
-  inspect!(set1, content="@IndexSet.of([3, 8, 1, 4])")
+  inspect(set1, content="@IndexSet.of([3, 8, 1, 4])")
 }
 
 ///|
 test "123" {
   let set = @IndexSet.of([100, 200, 300, 400, 500])
-  assert_eq!(set.get_at(0), Some(100))
-  assert_eq!(set.index_of(300), Some(2))
+  assert_eq(set.get_at(0), Some(100))
+  assert_eq(set.index_of(300), Some(2))
 }
 
 ///|
 test "new" {
   let m : @IndexSet.T[Int] = @IndexSet.new()
-  assert_eq!(m.capacity(), default_init_capacity)
-  assert_eq!(m.size(), 0)
+  assert_eq(m.capacity(), default_init_capacity)
+  assert_eq(m.size(), 0)
 }
 
 ///|
@@ -43,38 +43,38 @@ test "insert" {
   m.add("a")
   m.add("b")
   m.add("c")
-  assert_true!(m.contains("a"))
-  assert_true!(m.contains("b"))
-  assert_true!(m.contains("c"))
-  assert_false!(m.contains("d"))
+  assert_true(m.contains("a"))
+  assert_true(m.contains("b"))
+  assert_true(m.contains("c"))
+  assert_false(m.contains("d"))
 }
 
 ///|
 test "from_array" {
   let m = @IndexSet.of(["a", "b", "c"])
-  assert_true!(m.contains("a"))
-  assert_true!(m.contains("b"))
-  assert_true!(m.contains("c"))
-  assert_false!(m.contains("d"))
+  assert_true(m.contains("a"))
+  assert_true(m.contains("b"))
+  assert_true(m.contains("c"))
+  assert_false(m.contains("d"))
 }
 
 ///|
 test "size" {
   let m = @IndexSet.new()
-  assert_eq!(m.size(), 0)
+  assert_eq(m.size(), 0)
   m.add("a")
-  assert_eq!(m.size(), 1)
+  assert_eq(m.size(), 1)
 }
 
 ///|
 test "is_empty" {
   let m = @IndexSet.new()
-  assert_eq!(m.is_empty(), true)
+  assert_eq(m.is_empty(), true)
   m.add("a")
-  assert_eq!(m.is_empty(), false)
+  assert_eq(m.is_empty(), false)
   m.remove("a")
   m.remove("ccd")
-  assert_eq!(m.is_empty(), true)
+  assert_eq(m.is_empty(), true)
 }
 
 ///|
@@ -82,7 +82,7 @@ test "iter" {
   let m = @IndexSet.of(["a", "b", "c"])
   let mut sum = ""
   m.each(fn(k) { sum += k })
-  inspect!(sum, content="abc")
+  inspect(sum, content="abc")
 }
 
 ///|
@@ -94,8 +94,8 @@ test "iteri" {
     s += k
     sum += i
   })
-  inspect!(s, content="123")
-  inspect!(sum, content="3")
+  inspect(s, content="123")
+  inspect(sum, content="3")
 }
 
 ///|
@@ -103,11 +103,11 @@ test "union" {
   let m1 = @IndexSet.of(["a", "b", "c"])
   let m2 = @IndexSet.of(["b", "c", "d"])
   let m = m1.union(m2)
-  assert_eq!(m.size(), 4)
-  assert_true!(m.contains("a"))
-  assert_true!(m.contains("b"))
-  assert_true!(m.contains("c"))
-  assert_true!(m.contains("d"))
+  assert_eq(m.size(), 4)
+  assert_true(m.contains("a"))
+  assert_true(m.contains("b"))
+  assert_true(m.contains("c"))
+  assert_true(m.contains("d"))
 }
 
 ///|
@@ -115,11 +115,11 @@ test "intersection" {
   let m1 = @IndexSet.of(["a", "b", "c"])
   let m2 = @IndexSet.of(["b", "c", "d"])
   let m = m1.intersection(m2)
-  assert_eq!(m.size(), 2)
-  assert_false!(m.contains("a"))
-  assert_true!(m.contains("b"))
-  assert_true!(m.contains("c"))
-  assert_false!(m.contains("d"))
+  assert_eq(m.size(), 2)
+  assert_false(m.contains("a"))
+  assert_true(m.contains("b"))
+  assert_true(m.contains("c"))
+  assert_false(m.contains("d"))
 }
 
 ///|
@@ -127,11 +127,11 @@ test "difference" {
   let m1 = @IndexSet.of(["a", "b", "c"])
   let m2 = @IndexSet.of(["b", "c", "d"])
   let m = m1.difference(m2)
-  assert_eq!(m.size(), 1)
-  assert_true!(m.contains("a"))
-  assert_false!(m.contains("b"))
-  assert_false!(m.contains("c"))
-  assert_false!(m.contains("d"))
+  assert_eq(m.size(), 1)
+  assert_true(m.contains("a"))
+  assert_false(m.contains("b"))
+  assert_false(m.contains("c"))
+  assert_false(m.contains("d"))
 }
 
 ///|
@@ -139,11 +139,11 @@ test "symmetric_difference" {
   let m1 = @IndexSet.of(["a", "b", "c"])
   let m2 = @IndexSet.of(["b", "c", "d"])
   let m = m1.symmetric_difference(m2)
-  assert_eq!(m.size(), 2)
-  assert_true!(m.contains("a"))
-  assert_false!(m.contains("b"))
-  assert_false!(m.contains("c"))
-  assert_true!(m.contains("d"))
+  assert_eq(m.size(), 2)
+  assert_true(m.contains("a"))
+  assert_false(m.contains("b"))
+  assert_false(m.contains("c"))
+  assert_true(m.contains("d"))
 }
 
 ///|
@@ -151,20 +151,20 @@ test "iter" {
   let buf = StringBuilder::new(size_hint=20)
   let map = @IndexSet.of(["a", "b", "c"])
   map.iter().each(fn(e) { buf.write_string("[\{e}]") })
-  inspect!(buf, content="[a][b][c]")
+  inspect(buf, content="[a][b][c]")
   buf.reset()
   map.iter().take(2).each(fn(e) { buf.write_string("[\{e}]") })
-  inspect!(buf, content="[a][b]")
+  inspect(buf, content="[a][b]")
 }
 
 ///|
 test "from_array" {
   let arr = ["a", "b", "c"]
   let m = @IndexSet.from_array(arr)
-  assert_true!(m.contains("a"))
-  assert_true!(m.contains("b"))
-  assert_true!(m.contains("c"))
-  assert_false!(m.contains("d"))
+  assert_true(m.contains("a"))
+  assert_true(m.contains("b"))
+  assert_true(m.contains("c"))
+  assert_false(m.contains("d"))
 }
 
 ///|
@@ -173,8 +173,8 @@ test "insert_and_grow" {
   for i in 0..<10 {
     m.add(i.to_string())
   }
-  assert_eq!(m.size(), 10)
-  assert_eq!(m.capacity(), 16)
+  assert_eq(m.size(), 10)
+  assert_eq(m.capacity(), 16)
 }
 
 ///|
@@ -185,19 +185,19 @@ test "remove_and_shift_back" {
   m.add("c")
   m.add("d")
   m.remove("b")
-  assert_false!(m.contains("b"))
-  assert_true!(m.contains("a"))
-  assert_true!(m.contains("c"))
-  assert_true!(m.contains("d"))
+  assert_false(m.contains("b"))
+  assert_true(m.contains("a"))
+  assert_true(m.contains("c"))
+  assert_true(m.contains("d"))
 }
 
 ///|
 test "capacity_and_size" {
   let m = @IndexSet.new()
-  assert_eq!(m.capacity(), default_init_capacity)
-  assert_eq!(m.size(), 0)
+  assert_eq(m.capacity(), default_init_capacity)
+  assert_eq(m.size(), 0)
   m.add("a")
-  assert_eq!(m.size(), 1)
+  assert_eq(m.size(), 1)
 }
 
 ///|
@@ -206,10 +206,10 @@ test "clear_and_reinsert" {
   m.add("a")
   m.add("b")
   m.clear()
-  assert_eq!(m.size(), 0)
+  assert_eq(m.size(), 0)
   m.add("c")
-  assert_eq!(m.size(), 1)
-  assert_true!(m.contains("c"))
+  assert_eq(m.size(), 1)
+  assert_true(m.contains("c"))
 }
 
 ///|
@@ -218,8 +218,8 @@ test "insert_and_grow" {
   for i in 0..<10 {
     m.add(i.to_string())
   }
-  assert_eq!(m.size(), 10)
-  assert_eq!(m.capacity(), 16)
+  assert_eq(m.size(), 10)
+  assert_eq(m.capacity(), 16)
 }
 
 ///|
@@ -230,19 +230,19 @@ test "remove_and_shift_back" {
   m.add("c")
   m.add("d")
   m.remove("b")
-  assert_false!(m.contains("b"))
-  assert_true!(m.contains("a"))
-  assert_true!(m.contains("c"))
-  assert_true!(m.contains("d"))
+  assert_false(m.contains("b"))
+  assert_true(m.contains("a"))
+  assert_true(m.contains("c"))
+  assert_true(m.contains("d"))
 }
 
 ///|
 test "capacity_and_size" {
   let m = @IndexSet.new()
-  assert_eq!(m.capacity(), default_init_capacity)
-  assert_eq!(m.size(), 0)
+  assert_eq(m.capacity(), default_init_capacity)
+  assert_eq(m.size(), 0)
   m.add("a")
-  assert_eq!(m.size(), 1)
+  assert_eq(m.size(), 1)
 }
 
 ///|
@@ -251,15 +251,15 @@ test "clear_and_reinsert" {
   m.add("a")
   m.add("b")
   m.clear()
-  assert_eq!(m.size(), 0)
+  assert_eq(m.size(), 0)
   m.add("c")
-  assert_eq!(m.size(), 1)
-  assert_true!(m.contains("c"))
+  assert_eq(m.size(), 1)
+  assert_true(m.contains("c"))
 }
 
 ///|
 test "from_iter multiple elements iter" {
-  inspect!(
+  inspect(
     @IndexSet.from_iter([1, 2, 3].iter()),
     content="@IndexSet.of([1, 2, 3])",
   )
@@ -267,23 +267,23 @@ test "from_iter multiple elements iter" {
 
 ///|
 test "from_iter single element iter" {
-  inspect!(@IndexSet.from_iter([1].iter()), content="@IndexSet.of([1])")
+  inspect(@IndexSet.from_iter([1].iter()), content="@IndexSet.of([1])")
 }
 
 ///|
 test "from_iter empty iter" {
   let map : @IndexSet.T[Int] = @IndexSet.from_iter(Iter::empty())
-  inspect!(map, content="@IndexSet.of([])")
+  inspect(map, content="@IndexSet.of([])")
 }
 
 ///|
 test "IndexSet arbitrary" {
   let samples : Array[@IndexSet.T[Int]] = @quickcheck.samples(20)
-  inspect!(
+  inspect(
     samples[5:10],
     content="[@IndexSet.of([]), @IndexSet.of([]), @IndexSet.of([0]), @IndexSet.of([0]), @IndexSet.of([0, 2, 3, 1])]",
   )
-  inspect!(
+  inspect(
     samples[11:15],
     content="[@IndexSet.of([0, -1, -2]), @IndexSet.of([0, -2, -5, 4, 8]), @IndexSet.of([0, -1, 2]), @IndexSet.of([0])]",
   )
@@ -292,14 +292,14 @@ test "IndexSet arbitrary" {
 ///|
 test "@IndexSet.to_array/empty" {
   let set : @IndexSet.T[Int] = @IndexSet.new()
-  inspect!(@IndexSet.to_array(set), content="[]")
+  inspect(@IndexSet.to_array(set), content="[]")
 }
 
 ///|
 test "@IndexSet.to_array/single" {
   let set = @IndexSet.new()
   set.add(42)
-  inspect!(@IndexSet.to_array(set), content="[42]")
+  inspect(@IndexSet.to_array(set), content="[42]")
 }
 
 ///|
@@ -309,67 +309,67 @@ test "@IndexSet.to_array/multiple" {
   set.add(2)
   set.add(3)
   set.add(4)
-  inspect!(@IndexSet.to_array(set), content="[1, 2, 3, 4]")
+  inspect(@IndexSet.to_array(set), content="[1, 2, 3, 4]")
 }
 
 ///|
 test "peek_first" {
   let m = @IndexSet.new()
-  assert_eq!(m.peek_first(), None)
+  assert_eq(m.peek_first(), None)
   m.add("a")
   m.add("b")
   m.add("c")
-  assert_eq!(m.peek_first(), Some("a"))
+  assert_eq(m.peek_first(), Some("a"))
   m.remove("a")
-  assert_eq!(m.peek_first(), Some("b"))
+  assert_eq(m.peek_first(), Some("b"))
   m.clear()
-  assert_eq!(m.peek_first(), None)
+  assert_eq(m.peek_first(), None)
 }
 
 ///|
 test "peek_last" {
   let m = @IndexSet.new()
-  assert_eq!(m.peek_last(), None)
+  assert_eq(m.peek_last(), None)
   m.add("a")
   m.add("b")
   m.add("c")
-  assert_eq!(m.peek_last(), Some("c"))
+  assert_eq(m.peek_last(), Some("c"))
   m.remove("c")
-  assert_eq!(m.peek_last(), Some("b"))
+  assert_eq(m.peek_last(), Some("b"))
   m.clear()
-  assert_eq!(m.peek_last(), None)
+  assert_eq(m.peek_last(), None)
 }
 
 ///|
 test "pop" {
   let m = @IndexSet.new()
-  assert_eq!(m.pop(), None)
+  assert_eq(m.pop(), None)
   m.add("a")
   m.add("b")
   m.add("c")
-  assert_eq!(m.pop(), Some("c"))
-  assert_eq!(m.size(), 2)
-  assert_eq!(m.contains("c"), false)
-  assert_eq!(m.pop(), Some("b"))
-  assert_eq!(m.pop(), Some("a"))
-  assert_eq!(m.pop(), None)
-  assert_eq!(m.is_empty(), true)
+  assert_eq(m.pop(), Some("c"))
+  assert_eq(m.size(), 2)
+  assert_eq(m.contains("c"), false)
+  assert_eq(m.pop(), Some("b"))
+  assert_eq(m.pop(), Some("a"))
+  assert_eq(m.pop(), None)
+  assert_eq(m.is_empty(), true)
 }
 
 ///|
 test "shift" {
   let m = @IndexSet.new()
-  assert_eq!(m.shift(), None)
+  assert_eq(m.shift(), None)
   m.add("a")
   m.add("b")
   m.add("c")
-  assert_eq!(m.shift(), Some("a"))
-  assert_eq!(m.size(), 2)
-  assert_eq!(m.contains("a"), false)
-  assert_eq!(m.shift(), Some("b"))
-  assert_eq!(m.shift(), Some("c"))
-  assert_eq!(m.shift(), None)
-  assert_eq!(m.is_empty(), true)
+  assert_eq(m.shift(), Some("a"))
+  assert_eq(m.size(), 2)
+  assert_eq(m.contains("a"), false)
+  assert_eq(m.shift(), Some("b"))
+  assert_eq(m.shift(), Some("c"))
+  assert_eq(m.shift(), None)
+  assert_eq(m.is_empty(), true)
 }
 
 ///|
@@ -378,10 +378,10 @@ test "pop_and_peek" {
   m.add(1)
   m.add(2)
   m.add(3)
-  assert_eq!(m.peek_last(), Some(3))
-  assert_eq!(m.pop(), Some(3))
-  assert_eq!(m.peek_last(), Some(2))
-  assert_eq!(m.size(), 2)
+  assert_eq(m.peek_last(), Some(3))
+  assert_eq(m.pop(), Some(3))
+  assert_eq(m.peek_last(), Some(2))
+  assert_eq(m.size(), 2)
 }
 
 ///|
@@ -390,10 +390,10 @@ test "shift_and_peek" {
   m.add(1)
   m.add(2)
   m.add(3)
-  assert_eq!(m.peek_first(), Some(1))
-  assert_eq!(m.shift(), Some(1))
-  assert_eq!(m.peek_first(), Some(2))
-  assert_eq!(m.size(), 2)
+  assert_eq(m.peek_first(), Some(1))
+  assert_eq(m.shift(), Some(1))
+  assert_eq(m.peek_first(), Some(2))
+  assert_eq(m.size(), 2)
 }
 
 ///|
@@ -402,10 +402,10 @@ test "sorted" {
   let sorted_set = set.sorted(fn(a, b) { a - b })
 
   // 原集合保持不变
-  assert_eq!(set.to_array(), [5, 2, 4, 1, 3])
+  assert_eq(set.to_array(), [5, 2, 4, 1, 3])
 
   // 新集合已排序
-  assert_eq!(sorted_set.to_array(), [1, 2, 3, 4, 5])
+  assert_eq(sorted_set.to_array(), [1, 2, 3, 4, 5])
 }
 
 ///|
@@ -414,10 +414,10 @@ test "sorted_by_key" {
   let sorted_set = set.sorted_by_key()
 
   // 原集合保持不变
-  assert_eq!(set.to_array(), [5, 2, 4, 1, 3])
+  assert_eq(set.to_array(), [5, 2, 4, 1, 3])
 
   // 新集合已按自然顺序排序
-  assert_eq!(sorted_set.to_array(), [1, 2, 3, 4, 5])
+  assert_eq(sorted_set.to_array(), [1, 2, 3, 4, 5])
 }
 
 ///|
@@ -427,10 +427,10 @@ test "sorted_by" {
   let sorted_set = set.sorted_by(fn(n) { n % 10 })
 
   // 原集合保持不变
-  assert_eq!(set.to_array(), [12, 5, 8, 3, 16, 7])
+  assert_eq(set.to_array(), [12, 5, 8, 3, 16, 7])
 
   // 新集合按余数排序：12(2), 3(3), 5(5), 16(6), 7(7), 8(8)
-  assert_eq!(sorted_set.to_array(), [12, 3, 5, 16, 7, 8])
+  assert_eq(sorted_set.to_array(), [12, 3, 5, 16, 7, 8])
 }
 
 ///|
@@ -439,10 +439,10 @@ test "sort" {
   set.sort(fn(a, b) { a - b })
 
   // 集合已排序
-  assert_eq!(set.to_array(), [1, 2, 3, 4, 5])
+  assert_eq(set.to_array(), [1, 2, 3, 4, 5])
   let set2 = @IndexSet.of([1])
   set.sort(fn(a, b) { b - a })
-  assert_eq!(set2.to_array(), [1])
+  assert_eq(set2.to_array(), [1])
 }
 
 ///|
@@ -451,7 +451,7 @@ test "sort_by_key" {
   set.sort_by_key()
 
   // 集合已按自然顺序排序
-  assert_eq!(set.to_array(), [1, 2, 3, 4, 5])
+  assert_eq(set.to_array(), [1, 2, 3, 4, 5])
 }
 
 ///|
@@ -460,10 +460,10 @@ test "sort_only_one" {
   set.sort(fn(a, b) { a - b })
 
   // 集合已排序
-  assert_eq!(set.to_array(), [5])
+  assert_eq(set.to_array(), [5])
   let set2 = @IndexSet.of([5])
   set.sort(fn(a, b) { b - a })
-  assert_eq!(set2.to_array(), [5])
+  assert_eq(set2.to_array(), [5])
 }
 
 ///|
@@ -472,7 +472,7 @@ test "sort_by_key" {
   set.sort_by_key()
 
   // 集合已按自然顺序排序
-  assert_eq!(set.to_array(), [1, 2, 3, 4, 5])
+  assert_eq(set.to_array(), [1, 2, 3, 4, 5])
 }
 
 ///|
@@ -484,7 +484,7 @@ test "sort_by" {
   set.sort_by(fn(s) { s.length() })
 
   // 集合已按字符串长度排序: kiwi(4), apple(5), grape(5), banana(6), orange(6)
-  assert_eq!(set.to_array(), ["kiwi", "apple", "grape", "banana", "orange"])
+  assert_eq(set.to_array(), ["kiwi", "apple", "grape", "banana", "orange"])
 }
 
 ///|
@@ -493,10 +493,10 @@ test "sorted_desc" {
   let sorted_set = set.sorted_desc(fn(a, b) { a - b })
 
   // 原集合保持不变
-  assert_eq!(set.to_array(), [1, 4, 2, 5, 3])
+  assert_eq(set.to_array(), [1, 4, 2, 5, 3])
 
   // 新集合已降序排序
-  assert_eq!(sorted_set.to_array(), [5, 4, 3, 2, 1])
+  assert_eq(sorted_set.to_array(), [5, 4, 3, 2, 1])
 }
 
 ///|
@@ -505,10 +505,10 @@ test "sorted_by_key_desc" {
   let sorted_set = set.sorted_by_key_desc()
 
   // 原集合保持不变
-  assert_eq!(set.to_array(), [1, 4, 2, 5, 3])
+  assert_eq(set.to_array(), [1, 4, 2, 5, 3])
 
   // 新集合已按自然顺序降序排序
-  assert_eq!(sorted_set.to_array(), [5, 4, 3, 2, 1])
+  assert_eq(sorted_set.to_array(), [5, 4, 3, 2, 1])
 }
 
 ///|
@@ -517,7 +517,7 @@ test "sort_desc" {
   set.sort_desc(fn(a, b) { a - b })
 
   // 集合已降序排序
-  assert_eq!(set.to_array(), [5, 4, 3, 2, 1])
+  assert_eq(set.to_array(), [5, 4, 3, 2, 1])
 }
 
 ///|
@@ -526,7 +526,7 @@ test "sort_by_key_desc" {
   set.sort_by_key_desc()
 
   // 集合已按自然顺序降序排序
-  assert_eq!(set.to_array(), [5, 4, 3, 2, 1])
+  assert_eq(set.to_array(), [5, 4, 3, 2, 1])
 }
 
 ///|
@@ -534,11 +534,11 @@ test "get_at basic functionality" {
   let set = @IndexSet.of([10, 20, 30, 40, 50])
 
   // 测试正常索引访问
-  assert_eq!(set.get_at(0), Some(10))
-  assert_eq!(set.get_at(1), Some(20))
-  assert_eq!(set.get_at(2), Some(30))
-  assert_eq!(set.get_at(3), Some(40))
-  assert_eq!(set.get_at(4), Some(50))
+  assert_eq(set.get_at(0), Some(10))
+  assert_eq(set.get_at(1), Some(20))
+  assert_eq(set.get_at(2), Some(30))
+  assert_eq(set.get_at(3), Some(40))
+  assert_eq(set.get_at(4), Some(50))
 
   // 测试索引顺序符合插入顺序
   let values = []
@@ -548,7 +548,7 @@ test "get_at basic functionality" {
       None => ignore(None) // 不应发生
     }
   }
-  assert_eq!(values, [10, 20, 30, 40, 50])
+  assert_eq(values, [10, 20, 30, 40, 50])
 }
 
 ///|
@@ -556,13 +556,13 @@ test "get_at boundary cases" {
   let set = @IndexSet.of([1, 2, 3])
 
   // 测试边界情况
-  assert_eq!(set.get_at(-1), None) // 负索引
-  assert_eq!(set.get_at(3), None) // 越界索引
-  assert_eq!(set.get_at(100), None) // 远超越界索引
+  assert_eq(set.get_at(-1), None) // 负索引
+  assert_eq(set.get_at(3), None) // 越界索引
+  assert_eq(set.get_at(100), None) // 远超越界索引
 
   // 空集合测试
   let empty_set = @IndexSet.new()
-  assert_eq!(empty_set.get_at(0), None) // 空集合任何索引都返回None
+  assert_eq(empty_set.get_at(0), None) // 空集合任何索引都返回None
 }
 
 ///|
@@ -570,15 +570,15 @@ test "index_of basic functionality" {
   let set = @IndexSet.of(["apple", "banana", "cherry", "date", "elderberry"])
 
   // 测试正常元素查找
-  assert_eq!(set.index_of("apple"), Some(0))
-  assert_eq!(set.index_of("banana"), Some(1))
-  assert_eq!(set.index_of("cherry"), Some(2))
-  assert_eq!(set.index_of("date"), Some(3))
-  assert_eq!(set.index_of("elderberry"), Some(4))
+  assert_eq(set.index_of("apple"), Some(0))
+  assert_eq(set.index_of("banana"), Some(1))
+  assert_eq(set.index_of("cherry"), Some(2))
+  assert_eq(set.index_of("date"), Some(3))
+  assert_eq(set.index_of("elderberry"), Some(4))
 
   // 测试不存在的元素
-  assert_eq!(set.index_of("fig"), None)
-  assert_eq!(set.index_of("grape"), None)
+  assert_eq(set.index_of("fig"), None)
+  assert_eq(set.index_of("grape"), None)
 }
 
 ///|
@@ -598,14 +598,14 @@ test "remove_nonexistent_key" {
   set.remove("nonexistent_key")
 
   // 验证集合状态未改变
-  assert_eq!(set.size(), initial_size)
-  assert_eq!(set.to_array(), initial_elements)
+  assert_eq(set.size(), initial_size)
+  assert_eq(set.to_array(), initial_elements)
 
   // 确认原有元素仍然存在
-  assert_true!(set.contains("key1"))
-  assert_true!(set.contains("key2"))
-  assert_true!(set.contains("key3"))
+  assert_true(set.contains("key1"))
+  assert_true(set.contains("key2"))
+  assert_true(set.contains("key3"))
 
   // 确认不存在的键仍然不存在
-  assert_false!(set.contains("nonexistent_key"))
+  assert_false(set.contains("nonexistent_key"))
 }

--- a/src/types.mbt
+++ b/src/types.mbt
@@ -11,7 +11,7 @@ priv struct Bucket[K] {
   key : K // 键
   mut next : Int // 链表后继索引，-1表示没有后继
   mut prev : Int // 链表前驱索引，-1表示没有前驱
-} derive(Show)
+}
 
 /// A mutable indexed hash set implements with Robin Hood hashing.
 ///
@@ -28,7 +28,7 @@ priv struct IndexSetCore[K] {
   mut tail : Int // 链表尾节点索引，-1表示空链表
   mut position_to_idx : Array[Int] // 新增：位置到桶索引的映射
   mut idx_to_position : @hashmap.T[Int, Int] // 新增：桶索引到位置的映射
-} derive(Show)
+}
 
 ///|
 /// Mutable indexed hash set, not thread safe.
@@ -37,10 +37,10 @@ priv struct IndexSetCore[K] {
 /// # Example
 ///
 /// ```
-/// let set = @indexset.of([3, 8, 1])
+/// let set = @IndexSet.of([3, 8, 1])
 /// set.add(4)
-/// assert_eq!(set.contains(4), true)
-/// assert_eq!(set.get_at(3), 4)  // Access by index
+/// assert_eq(set.contains(4), true)
+/// assert_eq(set.get_at(3), Some(4))  // Access by index
 /// ```
 struct T[K] {
   core : IndexSetCore[K] // 包含核心数据结构


### PR DESCRIPTION
> [!NOTE]
> This PR was made by an LLM agent.

- Fix error 4020: Update package reference from @indexset to @IndexSet in documentation
- Fix warning 0053: Remove unused Hash trait bound from insert_into_table function  
- Fix warning 0001: Remove unused Show trait implementations from Bucket and IndexSetCore structs
- Fix warning 0027: Update deprecated method call syntax from @IndexSet.to_array(set) to set.to_array()
- Fix warning 0027: Update deprecated function declaration syntax from fn f[K] to fn[K] f
- Fix warning 0027: Update deprecated assert_eq! syntax to assert_eq in documentation
- Fix warning 0013: Resolve unresolved type variables by adding explicit type annotations
- Fix documentation example return type for get_at method to match Option return type

All tests continue to pass after these fixes.